### PR TITLE
Bug fix: password_hash() params

### DIFF
--- a/ch18/html/forgot_password.php
+++ b/ch18/html/forgot_password.php
@@ -31,7 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
 		// Create a new, random password:
 		$p = substr(md5(uniqid(rand(), true)), 3, 15);
-		$ph = password_hash($p);
+		$ph = password_hash($p, PASSWORD_DEFAULT);
 
 		// Update the database:
 		$q = "UPDATE users SET pass='$ph' WHERE user_id=$uid LIMIT 1";


### PR DESCRIPTION
Small bug fix for the password_hash() function used in this code as only 1 parameter defined yet 2 must be declared and I have used what I believe to be the best option for this fix.

Hope this helps.